### PR TITLE
Setup for Deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN groupadd -g 901 -r sivdev \
     && useradd -g sivdev -r -u 901 sivdev_user \
     && pip install --no-cache-dir -r /tmp/requirements_dev.txt
 
-EXPOSE 8000 8100
+EXPOSE 8100
 
 # Switch from root user for security
 # USER sivdev_user

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN groupadd -g 901 -r sivdev \
     && useradd -g sivdev -r -u 901 sivdev_user \
     && pip install --no-cache-dir -r /tmp/requirements_dev.txt
 
-EXPOSE 5000
+EXPOSE 8000 8100
 
 # Switch from root user for security
 # USER sivdev_user

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,6 +19,8 @@ services:
       DJANGO_SETTINGS_MODULE: streetteam.settings
       DB_URI: ${STREETTEAM_DB_URI}
       TWILIO_AUTH_TOKEN: ${TWILIO_AUTH_TOKEN}
+    volumes:
+      - .:/app/
     stdin_open: true
     tty: true
     networks:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,7 +19,7 @@ services:
       DJANGO_SETTINGS_MODULE: streetteam.settings
       DB_URI: ${STREETTEAM_DB_URI}
       TWILIO_AUTH_TOKEN: ${TWILIO_AUTH_TOKEN}
-    volumes:
+    volumes:  # TODO: once we move to image, we wont' need to do this
       - .:/app/
     stdin_open: true
     tty: true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,18 +8,17 @@ networks:
 
 services:
   app:
-    image: alysivji/streetteam:latest
+    build:
+      context: .
+      dockerfile: ./Dockerfile
     command: webserver
     environment:
-      IN_PRODUCTION: 1
+      IN_PRODUCTION: '1'
       PYTHONPATH: /app/streetteam
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
       DJANGO_SETTINGS_MODULE: streetteam.settings
       DB_URI: ${STREETTEAM_DB_URI}
-    volumes:
-      - .:/app/
-    ports:
-      - 8000:8000
+      TWILIO_AUTH_TOKEN: ${TWILIO_AUTH_TOKEN}
     stdin_open: true
     tty: true
     networks:
@@ -30,4 +29,5 @@ services:
       - traefik.docker.network=sivnet
       - traefik.backend=streetteam
       - traefik.frontend.rule=Host:streetteam.sivji.com
-      - traefik.port=8000
+      - traefik.frontend.headers.SSLProxyHeaders=X-Forwarded-Proto:https
+      - traefik.port=8100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,6 @@ services:
     volumes:
       - .:/app/
     ports:
-      - 8000:8000
+      - 8100:8100
     stdin_open: true
     tty: true

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -25,6 +25,7 @@ if [ "$SERVER" = "webserver" ]; then
     python manage.py migrate
     python manage.py collectstatic --no-input
     if [ "$PRODUCTION" = 1 ]; then
+        # TODO remove --reload once we move to image
         gunicorn "streetteam.wsgi" -b 0.0.0.0:8100 --reload --env DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
     elif [ "$PRODUCTION" = 0 ]; then
         gunicorn "streetteam.wsgi" -b 0.0.0.0:8100 --reload --env DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,13 +9,15 @@ SERVER=${1:-$DEFAULT}
 # Set a default value for production status
 PRODUCTION=${IN_PRODUCTION:-0}
 
-# continue only if database is up
-printf "%s" "waiting for database ..."
-while ! ping -c 1 -n -w 1 db &> /dev/null
-do
-    printf "%c" "."
-done
-printf "\n%s\n"  "Database is online!"
+if [ "$PRODUCTION" = 0 ]; then
+    # continue only if database is up (local only)
+    printf "%s" "waiting for database ..."
+    while ! ping -c 1 -n -w 1 db &> /dev/null
+    do
+        printf "%c" "."
+    done
+    printf "\n%s\n"  "Database is online!"
+fi
 
 if [ "$SERVER" = "webserver" ]; then
     echo "Starting Django server"
@@ -23,7 +25,7 @@ if [ "$SERVER" = "webserver" ]; then
     python manage.py migrate
     python manage.py collectstatic --no-input
     if [ "$PRODUCTION" = 1 ]; then
-        gunicorn "streetteam.wsgi" -b 0.0.0.0:8000 --env DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
+        gunicorn "streetteam.wsgi" -b 0.0.0.0:8100 --reload --env DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
     elif [ "$PRODUCTION" = 0 ]; then
         gunicorn "streetteam.wsgi" -b 0.0.0.0:8000 --reload --env DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
     else

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -27,7 +27,7 @@ if [ "$SERVER" = "webserver" ]; then
     if [ "$PRODUCTION" = 1 ]; then
         gunicorn "streetteam.wsgi" -b 0.0.0.0:8100 --reload --env DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
     elif [ "$PRODUCTION" = 0 ]; then
-        gunicorn "streetteam.wsgi" -b 0.0.0.0:8000 --reload --env DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
+        gunicorn "streetteam.wsgi" -b 0.0.0.0:8100 --reload --env DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
     else
         echo "Unrecognized option for variable IN_PRODUCTION: '$PRODUCTION'"
         exit 1

--- a/streetteam/apps/common/README.md
+++ b/streetteam/apps/common/README.md
@@ -1,0 +1,3 @@
+# Common
+
+Collection of tools and utilities used by our Django applications... but it's not an app in and of itself.

--- a/streetteam/apps/common/views.py
+++ b/streetteam/apps/common/views.py
@@ -1,5 +1,10 @@
+from django.conf import settings
+from django.utils.decorators import method_decorator
+
 from rest_framework.views import APIView
 from django.http import HttpResponse
+
+from apps.twilio_integration.decorators import validate_twilio_request
 
 
 class DebugEndpoint(APIView):
@@ -7,7 +12,7 @@ class DebugEndpoint(APIView):
         print(request.build_absolute_uri())
         return HttpResponse()
 
-    # @method_decorator(validate_twilio_request(settings.TWILIO_AUTH_TOKEN))
+    @method_decorator(validate_twilio_request(settings.TWILIO_AUTH_TOKEN))
     def post(self, request, format=None):
         print(request.build_absolute_uri())
         print(request.META)

--- a/streetteam/apps/common/views.py
+++ b/streetteam/apps/common/views.py
@@ -1,19 +1,10 @@
-from django.conf import settings
-from django.utils.decorators import method_decorator
-
 from rest_framework.views import APIView
 from django.http import HttpResponse
-
-from apps.twilio_integration.decorators import validate_twilio_request
 
 
 class DebugEndpoint(APIView):
     def get(self, request, format=None):
-        print(request.build_absolute_uri())
         return HttpResponse()
 
-    @method_decorator(validate_twilio_request(settings.TWILIO_AUTH_TOKEN))
     def post(self, request, format=None):
-        print(request.build_absolute_uri())
-        print(request.META)
         return HttpResponse()

--- a/streetteam/apps/common/views.py
+++ b/streetteam/apps/common/views.py
@@ -1,0 +1,13 @@
+from rest_framework.views import APIView
+from django.http import HttpResponse
+
+
+class DebugEndpoint(APIView):
+    def get(self, request, format=None):
+        print(request.build_absolute_uri())
+        return HttpResponse()
+
+    # @method_decorator(validate_twilio_request(settings.TWILIO_AUTH_TOKEN))
+    def post(self, request, format=None):
+        print(request.build_absolute_uri())
+        return HttpResponse()

--- a/streetteam/apps/common/views.py
+++ b/streetteam/apps/common/views.py
@@ -10,4 +10,5 @@ class DebugEndpoint(APIView):
     # @method_decorator(validate_twilio_request(settings.TWILIO_AUTH_TOKEN))
     def post(self, request, format=None):
         print(request.build_absolute_uri())
+        print(request.META)
         return HttpResponse()

--- a/streetteam/streetteam/settings.py
+++ b/streetteam/streetteam/settings.py
@@ -31,6 +31,7 @@ SECRET_KEY = (
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False if IN_PRODUCTION else True
+
 ALLOWED_HOSTS = ["0.0.0.0", ".sivji.com"] if IN_PRODUCTION else ["0.0.0.0", ".ngrok.io"]
 APPEND_SLASH = True
 

--- a/streetteam/streetteam/settings.py
+++ b/streetteam/streetteam/settings.py
@@ -32,7 +32,7 @@ SECRET_KEY = (
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False if IN_PRODUCTION else True
 
-# Development environment setting
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')  # set in traefik
 ALLOWED_HOSTS = ["0.0.0.0", ".sivji.com"] if IN_PRODUCTION else ["0.0.0.0", ".ngrok.io"]
 APPEND_SLASH = True
 

--- a/streetteam/streetteam/settings.py
+++ b/streetteam/streetteam/settings.py
@@ -31,10 +31,11 @@ SECRET_KEY = (
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False if IN_PRODUCTION else True
-
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')  # set in traefik
 ALLOWED_HOSTS = ["0.0.0.0", ".sivji.com"] if IN_PRODUCTION else ["0.0.0.0", ".ngrok.io"]
 APPEND_SLASH = True
+
+# set in traefik
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https') if IN_PRODUCTION else None
 
 # Application definition
 INSTALLED_APPS = [

--- a/streetteam/streetteam/settings.py
+++ b/streetteam/streetteam/settings.py
@@ -17,7 +17,7 @@ import dj_database_url
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # User defined vars
-IN_PRODUCTION = os.getenv("IN_PRODUCTION") == 1
+IN_PRODUCTION = os.getenv("IN_PRODUCTION") == '1'
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
@@ -33,7 +33,7 @@ SECRET_KEY = (
 DEBUG = False if IN_PRODUCTION else True
 
 # Development environment setting
-ALLOWED_HOSTS = ["0.0.0.0"] if IN_PRODUCTION else ["0.0.0.0", ".ngrok.io"]
+ALLOWED_HOSTS = ["0.0.0.0", ".sivji.com"] if IN_PRODUCTION else ["0.0.0.0", ".ngrok.io"]
 APPEND_SLASH = True
 
 # Application definition

--- a/streetteam/streetteam/urls.py
+++ b/streetteam/streetteam/urls.py
@@ -19,6 +19,8 @@ from django.conf.urls.static import static
 from django.http import HttpResponse
 from django.urls import include, path
 
+from apps.common.views import DebugEndpoint
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("integration/", include("apps.twilio_integration.urls")),
@@ -28,4 +30,5 @@ urlpatterns = [
             b'{"ping": "pong"}', content_type="application/json"
         ),
     ),
+    path("debug/", view=DebugEndpoint.as_view()),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Closes #4 

Since traefik takes care of HTTPS, we can set a security header there and have Django look to confirm it exists. Use Django's [`SECURE_PROXY_SSL_HEADER`](https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-SECURE_PROXY_SSL_HEADER) setting.