### PR TITLE
Serve static files using WhiteNoise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,10 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# project specific
+staticfiles/
+
+# environment specific
 .envrc
 .vscode
 .pdbrc.py

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,6 @@ test-covhtml: ## run tests and load html coverage report
 requirements: ## generate requirements.txt using piptools
 	pip-compile --output-file=requirements.txt requirements.in
 
-shell: ## log into into app container -- bash-shell
-	docker-compose exec app bash
-
 shell-db:  ## log into database container -- psql
 	docker-compose exec db psql -w --username "streetteam_user" --dbname "streetteam"
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,11 @@
 coverage==4.5.4
+dj-database-url==0.5.0
 Django==2.2.6
 djangorestframework==3.10.3
-dj-database-url==0.5.0
 gunicorn==19.9.0
 psycopg2-binary==2.8.4
-pytest==5.2.2
 pytest-cov==2.8.1
 pytest-django==3.6.0
+pytest==5.2.2
 twilio==6.33.0
+whitenoise==4.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ sqlparse==0.3.0           # via django
 twilio==6.33.0
 urllib3==1.25.6           # via requests
 wcwidth==0.1.7            # via pytest
+whitenoise==4.1.4

--- a/streetteam/streetteam/settings.py
+++ b/streetteam/streetteam/settings.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    'whitenoise.middleware.WhiteNoiseMiddleware',  # needs to be after security
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -115,8 +116,8 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 STATIC_URL = "/static/"
-# TODO THIS IS DURING DEVELOPMENT ONLY, FIGURE OUT A BETTER PATTERN FOR PROD
-STATIC_ROOT = "/tmp"
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # Custom Settings
 AUTH_USER_MODEL = "users.User"


### PR DESCRIPTION
Closes #3 

We are using [WhiteNoise](http://whitenoise.evans.io/en/stable/index.html) to serve static assets. This is a good solution that doesn't require a lot of configuration, which is the best way forward.

If this app ever takes off, we need to throw WhiteNoise behind a CDN. Their documentation has instructions on how to do that.

Also if we ever want to have users upload media directly to the web app, we will need to configure S3 to handle media files. [tutorial](https://testdriven.io/blog/storing-django-static-and-media-files-on-amazon-s3/)