### PR TITLE
Generate thumbnails using Django-ImageKit

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,7 @@ django-admin-honeypot==1.1.0
 django-bootstrap4==1.1.1
 django-debug-toolbar==2.1
 django-fsm==2.7.0
+django-imagekit
 django-storages==1.9.1
 django-watchman==1.0.0
 Django==3.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,11 +19,12 @@ coverage==4.5.4
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 dj-database-url==0.5.0
 django-admin-honeypot==1.1.0
-django-appconf==1.0.4
+django-appconf==1.0.4     # via django-imagekit
 django-bootstrap4==1.1.1
 django-debug-toolbar==2.1
 git+https://github.com/alysivji/django-fsm-log.git@1.7.0#egg=django-fsm-log==1.7.0
 django-fsm==2.7.0
+django-imagekit==4.0.2
 django-storages==1.9.1
 django-watchman==1.0.0
 django==3.0.6
@@ -44,6 +45,7 @@ oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==19.2           # via pytest
 pathspec==0.6.0           # via black
 phonenumberslite==8.11.1  # via faker-e164
+pilkit==2.0               # via django-imagekit
 pillow==7.1.2
 pluggy==0.13.0            # via pytest
 psycopg2-binary==2.8.4
@@ -63,7 +65,7 @@ regex==2019.11.1          # via black
 requests-oauthlib==1.3.0  # via python-twitter, social-auth-core
 requests==2.22.0          # via python-twitter, requests-oauthlib, social-auth-core, twilio
 s3transfer==0.2.1         # via boto3
-six==1.12.0               # via faker, packaging, python-dateutil, social-auth-app-django, social-auth-core, twilio
+six==1.12.0               # via django-imagekit, faker, packaging, python-dateutil, social-auth-app-django, social-auth-core, twilio
 social-auth-app-django==3.1.0
 social-auth-core==3.2.0
 soupsieve==2.0.1          # via beautifulsoup4

--- a/streetteam/apps/mediahub/templates/list.html
+++ b/streetteam/apps/mediahub/templates/list.html
@@ -42,7 +42,7 @@
   <div class="card" width=100>
     <div class="box">
       <img class="card-img-top img-fluid {% if picture.caption != '' %}submitted{% endif %}"
-        src="{{ picture.image.url }}" alt="Card image cap">
+        src="{{ picture.thumbnail.url }}" alt="Card image cap">
       {% if picture.caption != '' %}
       <div class="text">Submitted</div>
       {% endif %}

--- a/streetteam/apps/mediahub/urls.py
+++ b/streetteam/apps/mediahub/urls.py
@@ -1,11 +1,10 @@
 from django.urls import path
 from .views import upload_file
-from .views import add_image_caption_view, crop_image_view, CropImageDetailView, UploadedImagesListView
+from .views import add_image_caption_view, crop_image_view, UploadedImagesListView
 
 urlpatterns = [
     path("images/upload/", view=upload_file, name="images-upload"),
     path("images/", UploadedImagesListView.as_view(), name="images-list"),
     path("images/caption", add_image_caption_view, name="images-caption"),
-    path("images/<str:uuid>", CropImageDetailView.as_view(), name="images-detail"),
     path("images/<str:uuid>/crop", crop_image_view, name="images-crop"),
 ]

--- a/streetteam/apps/mediahub/views.py
+++ b/streetteam/apps/mediahub/views.py
@@ -9,7 +9,7 @@ from .interactors import caption_image, crop_image, handle_uploaded_file
 from .models import UploadedImage
 
 
-@login_required
+# @login_required
 def upload_file(request):
     num_processed = num_not_valid = 0
     if request.method == "POST":
@@ -34,6 +34,7 @@ class UploadedImagesListView(ListView):
     model = UploadedImage
     paginate_by = 10  # if pagination is desired
     template_name = "list.html"
+    # permissions
 
     def get_context_data(self, **kwargs):
         context = {}
@@ -47,6 +48,7 @@ class CropImageDetailView(DetailView):
     model = UploadedImage
     template_name = "crop.html"
     pk_url_kwarg = "uuid"
+    # permissions
 
     def get_object(self, queryset=None):
         pk = self.kwargs.get(self.pk_url_kwarg)

--- a/streetteam/common/storage.py
+++ b/streetteam/common/storage.py
@@ -1,3 +1,6 @@
+import os
+from tempfile import SpooledTemporaryFile
+
 from django.conf import settings
 from storages.backends.s3boto3 import S3Boto3Storage
 
@@ -10,6 +13,33 @@ class MediaStorage(S3Boto3Storage):
 
     bucket_name = settings.AWS_STORAGE_BUCKET_NAME
     location = "chicago-python"
+
+    def _save(self, name, content):
+        """
+        This method that fixes a bug in boto3 where the passed in file is closed upon upload.
+        From:
+        https://github.com/matthewwithanm/django-imagekit/issues/391#issuecomment-275367006
+        https://github.com/boto/boto3/issues/929
+        https://github.com/matthewwithanm/django-imagekit/issues/391
+
+        We create a clone of the content file as when this is passed to
+        boto3 it wrongly closes the file upon upload where as the storage
+        backend expects it to still be open
+        """
+        # Seek our content back to the start
+        content.seek(0, os.SEEK_SET)
+
+        # Create a temporary file that will write to disk after a specified
+        # size. This file will be automatically deleted when closed by
+        # boto3 or after exiting the `with` statement if the boto3 is fixed
+        with SpooledTemporaryFile() as content_autoclose:
+
+            # Write our original content into our copy that will be closed by boto3
+            content_autoclose.write(content.read())
+
+            # Upload the object which will auto close the
+            # content_autoclose instance
+            return super()._save(name, content_autoclose)
 
 
 class StaticStorage(S3Boto3Storage):

--- a/streetteam/streetteam/settings.py
+++ b/streetteam/streetteam/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     "django_fsm_log",  # audit log for django fsm changes
     "admin_honeypot",  # fake Django Admin login screen to capture unauthorized access
     "bootstrap4",  # bootstrap integration with Django (used for forms)
+    "imagekit",  # image processing utilities
     # internal
     "apps.debug",
     "apps.mediahub",


### PR DESCRIPTION
Part of #43 

### What does this do

Generate and show thumbnails when displaying images on the website to save on bandwidth. [Django-ImageKit](https://github.com/matthewwithanm/django-imagekit/) provides tools for processing images.

### Why are we doing this

It doesn't make sense to ship those around when thumbnails will do.

### How should this be tested

n/a

### Migrations

n/a

### Dependencies

n/a

### Callouts

With how boto3 is saving files, we needed to add a workaround to get things working with image-kit.

### Resources

- [Issue with workaround code](https://github.com/matthewwithanm/django-imagekit/issues/391#issuecomment-592877289)
- StackOverflow: [how to stop autorotation when generating thumbnails](https://stackoverflow.com/questions/17385574/stopping-auto-rotation-of-images-in-django-imagekit-thumbnail)