### PR TITLE
pytest fixture to simplify datetime calculations

### DIFF
--- a/streetteam/apps/events/tests/functional_test.py
+++ b/streetteam/apps/events/tests/functional_test.py
@@ -1,6 +1,5 @@
-from datetime import datetime, timezone, timedelta
+from datetime import timedelta
 
-from dateutil.relativedelta import relativedelta
 import pytest
 
 from ..models import Event
@@ -11,14 +10,14 @@ from apps.teams.tests.factories import UserTeamMembershipFactory
 @pytest.mark.django_db
 @pytest.mark.end2end
 class TestCreatingEventWorkflow:
-    def test_create_new_event__happy_path(self, client, login_user):
+    def test_create_new_event__happy_path(self, client, login_user, ago):
         # Arrange
         admin_membership = UserTeamMembershipFactory(position_state=UserTeamMembership.PositionState.ADMIN)
         user = admin_membership.user
         team = admin_membership.team
         login_user(user)
 
-        tomorrow = datetime.now(timezone.utc) + relativedelta(days=1)
+        tomorrow = ago(days=-1)
 
         # Act
         form_data = {
@@ -36,14 +35,14 @@ class TestCreatingEventWorkflow:
         assert event.description == "My Description"
         assert abs(event.happens_on - tomorrow) <= timedelta(seconds=1)
 
-    def test_create_new_event__cannot_create_event_in_past(self, client, login_user):
+    def test_create_new_event__cannot_create_event_in_past(self, client, login_user, ago):
         # Arrange
         admin_membership = UserTeamMembershipFactory(position_state=UserTeamMembership.PositionState.ADMIN)
         user = admin_membership.user
         team = admin_membership.team
         login_user(user)
 
-        yesterday = datetime.now(timezone.utc) - relativedelta(days=1)
+        yesterday = ago(days=1)
 
         # Act
         form_data = {

--- a/streetteam/apps/events/tests/models_test.py
+++ b/streetteam/apps/events/tests/models_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timedelta, timezone
 import pytest
 
 from ..models import Event, is_future_event, is_past_event
@@ -19,34 +18,34 @@ class TestEventModel:
 
 @pytest.mark.django_db
 class TestEventStatustateMachine:
-    def test_is_future_event__event_happens_tomorrow(self):
-        tomorrow = datetime.now(timezone.utc) + timedelta(days=1)
+    def test_is_future_event__event_happens_tomorrow(self, ago):
+        tomorrow = ago(days=-1)
         event = EventFactory(happens_on=tomorrow)
         assert is_future_event(event) is True
 
     @pytest.mark.freeze_time
-    def test_is_future_event__event_happens_now(self, freezer):
-        now = datetime.now(timezone.utc)
+    def test_is_future_event__event_happens_now(self, freezer, ago):
+        now = ago()
         event = EventFactory(happens_on=now)
         assert is_future_event(event) is False
 
-    def test_is_future_event__event_happened_yesterday(self):
-        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    def test_is_future_event__event_happened_yesterday(self, ago):
+        yesterday = ago(days=1)
         event = EventFactory(happens_on=yesterday)
         assert is_future_event(event) is False
 
-    def test_is_past_event__event_happens_tomorrow(self):
-        tomorrow = datetime.now(timezone.utc) + timedelta(days=1)
+    def test_is_past_event__event_happens_tomorrow(self, ago):
+        tomorrow = ago(days=-1)
         event = EventFactory(happens_on=tomorrow)
         assert is_past_event(event) is False
 
     @pytest.mark.freeze_time
-    def test_is_past_event__event_happens_now(self, freezer):
-        now = datetime.now(timezone.utc)
+    def test_is_past_event__event_happens_now(self, freezer, ago):
+        now = ago()
         event = EventFactory(happens_on=now)
         assert is_past_event(event) is True
 
-    def test_is_past_event__event_happened_yesterday(self):
-        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    def test_is_past_event__event_happened_yesterday(self, ago):
+        yesterday = ago(days=1)
         event = EventFactory(happens_on=yesterday)
         assert is_past_event(event) is True

--- a/streetteam/apps/teams/tests/models_test.py
+++ b/streetteam/apps/teams/tests/models_test.py
@@ -1,5 +1,3 @@
-from datetime import datetime, timezone
-
 from dateutil.relativedelta import relativedelta
 from django.db import IntegrityError
 import pytest
@@ -67,9 +65,9 @@ class TestUserTeamMembershipStateMachine:
         assert not user_is_only_member_of_team(second_member)
 
     @pytest.mark.freeze_time
-    def test_team_was_just_created__happy_path(self, freezer):
+    def test_team_was_just_created__happy_path(self, freezer, ago):
         # Arrange
-        now = datetime.now(timezone.utc)
+        now = ago()
         fifty_nine_seconds_ago = now - relativedelta(seconds=59)
         freezer.move_to(fifty_nine_seconds_ago)
         team = TeamFactory()
@@ -82,9 +80,9 @@ class TestUserTeamMembershipStateMachine:
         assert result is True
 
     @pytest.mark.freeze_time
-    def test_team_was_just_created__boundary(self, freezer):
+    def test_team_was_just_created__boundary(self, freezer, ago):
         # Arrange
-        now = datetime.now(timezone.utc)
+        now = ago()
         sixty_seconds_ago = now - relativedelta(seconds=60)
         freezer.move_to(sixty_seconds_ago)
         team = TeamFactory()
@@ -97,10 +95,10 @@ class TestUserTeamMembershipStateMachine:
         assert result is False
 
     @pytest.mark.freeze_time
-    def test_team_was_just_created__outside_boundary(self, freezer):
+    def test_team_was_just_created__outside_boundary(self, freezer, ago):
         # Arrange
-        now = datetime.now(timezone.utc)
-        over_sixty_seconds_ago = now - relativedelta(seconds=61)
+        now = ago()
+        over_sixty_seconds_ago = ago(seconds=61)
         freezer.move_to(over_sixty_seconds_ago)
         team = TeamFactory()
         membership = UserTeamMembershipFactory(team=team, position_state=UserTeamMembership.PositionState.MEMBER)

--- a/streetteam/conftest.py
+++ b/streetteam/conftest.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+from dateutil.relativedelta import relativedelta
 import pytest
 from apps.users.tests.factories import UserFactory
 
@@ -22,3 +24,11 @@ def patcher(monkeypatch):
         return replacement
 
     yield _patcher
+
+
+@pytest.fixture
+def ago():
+    def _wrapper(**kwargs):
+        return datetime.now(timezone.utc) - relativedelta(**kwargs)
+
+    return _wrapper


### PR DESCRIPTION
### What does this do

Make a pytest fixture to simplify testing.

### Why are we doing this

Practice using plugins.

### How should this be tested

Do tests still pass?

### Migrations

n/a

### Dependencies

n/a

### Callouts

n/a